### PR TITLE
Move condition out of the copy-loop.

### DIFF
--- a/src/device/si/si_controller.c
+++ b/src/device/si/si_controller.c
@@ -64,12 +64,15 @@ static void copy_pif_rdram(struct si_controller* si)
     uint32_t* pif_ram = (uint32_t*)si->pif.ram;
     uint32_t* dram = (uint32_t*)(&si->ri->rdram.dram[rdram_dram_address(dram_addr)]);
 
-    for(i = 0; i < (PIF_RAM_SIZE / 4); ++i)
-    {
-        if (si->dma_dir == SI_DMA_WRITE)
+    if (si->dma_dir == SI_DMA_WRITE) {
+        for(i = 0; i < (PIF_RAM_SIZE / 4); ++i) {
             pif_ram[i] = sl(dram[i]);
-        else if (si->dma_dir == SI_DMA_READ)
+        }
+    }
+    else if (si->dma_dir == SI_DMA_READ) {
+        for(i = 0; i < (PIF_RAM_SIZE / 4); ++i) {
             dram[i] = sl(pif_ram[i]);
+        }
     }
 }
 


### PR DESCRIPTION
Small niptick : I moved outside of the copy-loop the dma_dir test as it doesn't depends on the loop counter. Also it should give better code.

Otherwise, this patch looks good and indeed fixes the input issue in Turok - Dinosaur Hunter.
Note that only the USA version was affected and not the European.